### PR TITLE
Reduce dependence on Polyfill for Linux OsRelease code

### DIFF
--- a/src/OsReleaseNet/LinuxOsReleaseProvider.cs
+++ b/src/OsReleaseNet/LinuxOsReleaseProvider.cs
@@ -7,9 +7,7 @@
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#if NETSTANDARD2_0 || NETSTANDARD2_1
-using OperatingSystem = Polyfills.OperatingSystemPolyfill;
-#else
+#if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
 #endif
 
@@ -17,6 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 using AlastairLundy.DotExtensions.Strings;
@@ -44,7 +43,7 @@ public class LinuxOsReleaseProvider : ILinuxOsReleaseProvider
 #endif
     public async Task<string?> GetReleaseInfoPropertyValueAsync(string propertyName)
     {
-        if (OperatingSystem.IsLinux() == false)
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) == false)
         {
             throw new PlatformNotSupportedException(Resources.Exceptions_PlatformNotSupported_LinuxOnly);
         }
@@ -57,7 +56,7 @@ public class LinuxOsReleaseProvider : ILinuxOsReleaseProvider
 
         resultArray = RemoveUnwantedCharacters(resultArray).ToArray();
         
-        string? result = resultArray.FirstOrDefault(x => x.Contains(propertyName));
+        string? result = resultArray.FirstOrDefault(x => x.ToUpper().Contains(propertyName.ToUpper()));
 
         if (result is not null)
         {
@@ -79,7 +78,7 @@ public class LinuxOsReleaseProvider : ILinuxOsReleaseProvider
 #endif
     public async Task<LinuxOsReleaseInfo> GetReleaseInfoAsync()
     {
-        if (OperatingSystem.IsLinux() == false)
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) == false)
         {
             throw new PlatformNotSupportedException(Resources.Exceptions_PlatformNotSupported_LinuxOnly);
         }
@@ -106,7 +105,7 @@ public class LinuxOsReleaseProvider : ILinuxOsReleaseProvider
 #endif
     public async Task<LinuxDistroBase> GetDistroBaseAsync()
     {
-        if (OperatingSystem.IsLinux() == false)
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) == false)
         {
             throw new PlatformNotSupportedException(Resources.Exceptions_PlatformNotSupported_LinuxOnly);
         }

--- a/src/OsReleaseNet/OsReleaseNet.csproj
+++ b/src/OsReleaseNet/OsReleaseNet.csproj
@@ -34,10 +34,6 @@
         <PackageReference Include="AlastairLundy.DotExtensions" Version="7.3.0" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
-        <PackageReference Include="Polyfill" Version="8.2.0" PrivateAssets="All"/>
-    </ItemGroup>
-
     <ItemGroup>
       <EmbeddedResource Update="Internal\Localizations\Resources.resx">
         <Generator>ResXFileCodeGenerator</Generator>

--- a/src/OsReleaseNet/OsReleaseNet.csproj
+++ b/src/OsReleaseNet/OsReleaseNet.csproj
@@ -34,10 +34,6 @@
         <PackageReference Include="AlastairLundy.DotExtensions" Version="7.2.0" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
-        <PackageReference Include="Polyfill" Version="8.0.1" PrivateAssets="All"/>
-    </ItemGroup>
-
     <ItemGroup>
       <EmbeddedResource Update="Internal\Localizations\Resources.resx">
         <Generator>ResXFileCodeGenerator</Generator>

--- a/src/OsReleaseNet/OsReleaseNet.csproj
+++ b/src/OsReleaseNet/OsReleaseNet.csproj
@@ -34,6 +34,10 @@
         <PackageReference Include="AlastairLundy.DotExtensions" Version="7.3.0" />
     </ItemGroup>
 
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
+        <PackageReference Include="Polyfill" Version="8.2.0" PrivateAssets="All"/>
+    </ItemGroup>
+
     <ItemGroup>
       <EmbeddedResource Update="Internal\Localizations\Resources.resx">
         <Generator>ResXFileCodeGenerator</Generator>

--- a/src/OsReleaseNet/SteamOsInfoProvider.cs
+++ b/src/OsReleaseNet/SteamOsInfoProvider.cs
@@ -11,15 +11,14 @@
 // ReSharper disable ConvertToPrimaryConstructor
 
 using System;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 using AlastairLundy.OsReleaseNet.Abstractions;
 
 using AlastairLundy.OsReleaseNet.Internal.Localizations;
 
-#if NETSTANDARD2_0 || NETSTANDARD2_1
-using OperatingSystem = Polyfills.OperatingSystemPolyfill;
-#else
+#if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
 #endif
 
@@ -131,7 +130,7 @@ public class SteamOsInfoProvider : ISteamOsInfoProvider
 #endif
     public async Task<bool> IsSteamOSAsync(bool includeHoloIsoAsSteamOs)
     {
-        if (OperatingSystem.IsLinux() == false)
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) == false)
         {
             throw new PlatformNotSupportedException(Resources.Exceptions_PlatformNotSupported_LinuxOnly);
         }


### PR DESCRIPTION
Keeping Polyfill as a dependency for now in case FreeBSD detection is added in 1.1